### PR TITLE
Fix file header line for ELPA compatibility

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -1,6 +1,10 @@
-;; org-present.el -- Minimalist presentation minor-mode for Emacs org-mode.
+;;; org-present.el --- Minimalist presentation minor-mode for Emacs org-mode.
 ;; 
 ;; Copyright (C) 2012 by Ric Lister
+;;
+;; Author: Ric Lister
+;; Package-Requires: ((org "7"))
+;; URL: https://github.com/rlister/org-present
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -18,6 +22,11 @@
 ;; along with GNU Emacs; if not, write to the Free Software
 ;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 ;; 02111-1307, USA.
+;;
+;;; Commentary:
+;;
+;; This is meant to be an extremely minimalist presentation tool for
+;; Emacs org-mode.
 ;;
 ;; Usage:
 ;;


### PR DESCRIPTION
We're [adding a recipe](https://github.com/milkypostman/melpa/pull/715) for `org-present` to [MELPA](http://melpa.milkbox.net/) so that any user of a recent Emacs (ie. with `package.el` present) can install it with a simple `M-x package-install`.

This commit makes `org-present.el` comply with `package.el`'s slightly pedantic requirements.

Cheers!

-Steve
