### PR TITLE
hide emphasis markers when presenting

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -153,7 +153,12 @@
     ;; hide stars in headings
     (goto-char (point-min))
     (while (re-search-forward "^\\(*+\\)" nil t)
-      (org-present-add-overlay (match-beginning 1) (match-end 1)))))
+      (org-present-add-overlay (match-beginning 1) (match-end 1)))
+    ;; hide emphasis markers
+    (goto-char (point-min))
+    (while (re-search-forward org-emph-re nil t)
+      (org-present-add-overlay (match-beginning 2) (1+ (match-beginning 2)))
+      (org-present-add-overlay (1- (match-end 2)) (match-end 2)))))
 
 (defun org-present-rm-overlays ()
   "Remove overlays for this mode."


### PR DESCRIPTION
Hi! I made a small enhancement: hiding emphasis markers in the same manner as we hide org-mode options and header stars while a presentation is active. This way you can still get bold, italic, underscore, etc., without showing the */_- characters.
