### PR TITLE
Fix the user set cursor being overridden

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -192,6 +192,9 @@
   (org-present-small)
   (org-present-rm-overlays)
   (widen)
+  ;; Exit from read-only mode before exiting the minor mode
+  (when buffer-read-only
+    (org-present-read-write))
   (run-hooks 'org-present-mode-quit-hook)
   (setq org-present-mode nil))
 


### PR DESCRIPTION
Function `org-present-read-only' sets the value of the cursor to nil
effectual throwing away the user set configuration. Using a temp
variable`org-present-cursor-cache' to fix that.
