### PR TITLE
Add org-present-after-navigate-functions abnormal hook

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -101,7 +101,8 @@
          (org-present-top)))    ;if that was last, go back to top before narrow
     ;; else handle title page before first heading
     (outline-next-heading))
-  (org-present-narrow))
+  (org-present-narrow)
+  (org-present-run-after-navigate-functions))
 
 (defun org-present-prev ()
   "Jump to previous top-level heading."
@@ -111,7 +112,8 @@
         (widen)
         (org-present-top)
         (org-get-last-sibling)))
-  (org-present-narrow))
+  (org-present-narrow)
+  (org-present-run-after-navigate-functions))
 
 (defun org-present-narrow ()
   "Show just current page; in a heading we narrow, else show title page (before first heading)."
@@ -129,7 +131,8 @@
   (interactive)
   (widen)
   (beginning-of-buffer)
-  (org-present-narrow))
+  (org-present-narrow)
+  (org-present-run-after-navigate-functions))
 
 (defun org-present-end ()
   "Jump to last slide of presentation."
@@ -137,7 +140,8 @@
   (widen)
   (end-of-buffer)
   (org-present-top)
-  (org-present-narrow))
+  (org-present-narrow)
+  (org-present-run-after-navigate-functions))
 
 (defun org-present-big ()
   "Make font size larger."
@@ -219,7 +223,8 @@
   (setq org-present-mode t)
   (org-present-add-overlays)
   (org-present-narrow)
-  (run-hooks 'org-present-mode-hook))
+  (run-hooks 'org-present-mode-hook)
+  (org-present-run-after-navigate-functions))
 
 (defun org-present-quit ()
   "Quit the minor-mode."
@@ -232,6 +237,23 @@
     (org-present-read-write))
   (run-hooks 'org-present-mode-quit-hook)
   (setq org-present-mode nil))
+
+(defvar org-present-after-navigate-functions nil
+  "Abnormal hook run after org-present navigates to a new heading.")
+
+;; courtesy Xah Lee ( http://ergoemacs.org/emacs/modernization_elisp_lib_problem.html )
+(defun org-present-trim-string (string)
+  "Remove whitespace (space, tab, emacs newline (LF, ASCII 10)) in beginning and ending of STRING."
+  (replace-regexp-in-string
+   "\\`[ \t\n]*" ""
+   (replace-regexp-in-string "[ \t\n]*\\'" "" string)))
+
+(defun org-present-run-after-navigate-functions ()
+  "Run org-present-after-navigate hook, passing the name of the presentation buffer and the current heading."
+  (let* ((title-text (thing-at-point 'line))
+         (safe-title-text (replace-regexp-in-string "^[ \*]" "" title-text))
+         (current-heading (org-present-trim-string safe-title-text)))
+    (run-hook-with-args 'org-present-after-navigate-functions (buffer-name) current-heading)))
 
 (provide 'org-present)
 ;;; org-present.el ends here


### PR DESCRIPTION
This adds a single abnormal hook (i.e., a hook which takes arguments) to org-present.

The hook is called after navigating to a new heading (including the initial heading after org-present is invoked).  It takes two parameters:

* the name of the presentation file, and
* the text of the heading.

E.g. the following code:

```elisp
(add-hook 'org-present-after-navigate-functions
          (lambda (name heading)
            (message (concatenate 'string name " - " heading))))
```
... will update the minibuffer with the name and heading every time the user navigates to a new heading.

This PR adds the sole hook necessary to implement https://github.com/rlister/org-present/pull/11 as an external plugin that uses both this hook, and the existing mode quit hook.