### PR TITLE
while presenting, also hide verbatim markers

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -184,6 +184,11 @@
     (goto-char (point-min))
     (while (re-search-forward org-emph-re nil t)
       (org-present-add-overlay (match-beginning 2) (1+ (match-beginning 2)))
+      (org-present-add-overlay (1- (match-end 2)) (match-end 2)))
+    ;; hide verbatim markers
+    (goto-char (point-min))
+    (while (re-search-forward org-verbatim-re nil t)
+      (org-present-add-overlay (match-beginning 2) (1+ (match-beginning 2)))
       (org-present-add-overlay (1- (match-end 2)) (match-end 2)))))
 
 (defun org-present-rm-overlays ()


### PR DESCRIPTION
Thanks for your work on org-present.
This simple change also hides the '~' and '=' markers in verbatim formatting.