### PR TITLE
Fix needless hiding of emphasis markers already hidden by Org

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -180,11 +180,14 @@
     (goto-char (point-min))
     (while (re-search-forward "^\\(*+\\)" nil t)
       (org-present-add-overlay (match-beginning 1) (match-end 1)))
-    ;; hide emphasis markers
-    (goto-char (point-min))
-    (while (re-search-forward org-emph-re nil t)
-      (org-present-add-overlay (match-beginning 2) (1+ (match-beginning 2)))
-      (org-present-add-overlay (1- (match-end 2)) (match-end 2)))))
+    ;; hide emphasis markers if not already hidden by org
+    (if org-hide-emphasis-markers nil
+      ;; TODO https://github.com/rlister/org-present/issues/12
+      ;; It would be better to reuse org's own facility for this, if possible.
+      (goto-char (point-min))
+      (while (re-search-forward org-emph-re nil t)
+        (org-present-add-overlay (match-beginning 2) (1+ (match-beginning 2)))
+        (org-present-add-overlay (1- (match-end 2)) (match-end 2))))))
 
 (defun org-present-rm-overlays ()
   "Remove overlays for this mode."


### PR DESCRIPTION
Fix needless (and buggy, compared to Org's default behavior) hiding of emphasis markers already hidden by Org. I spent some time trying to figure out how to clean up the current "hide emphasis markers" algorithm, evening looking at `org.el`, but couldn't figure it out (#12 is relevant here).