### PR TITLE
Add org-present-startup-folded a la org-startup-folded

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -249,6 +249,12 @@
   (run-hooks 'org-present-mode-quit-hook)
   (setq org-present-mode nil))
 
+(defvar org-present-startup-folded nil
+  "Like `org-startup-folded', but for presentation mode. Also analogous to
+introduction of slide items by effects in other presentation programs: i.e., if
+you do not want to show the whole slide at first, but to unfurl it slowly, set
+this to non-nil.")
+
 (defvar org-present-after-navigate-functions nil
   "Abnormal hook run after org-present navigates to a new heading.")
 
@@ -260,11 +266,14 @@
    (replace-regexp-in-string "[ \t\n]*\\'" "" string)))
 
 (defun org-present-run-after-navigate-functions ()
-  "Run org-present-after-navigate hook, passing the name of the presentation buffer and the current heading."
-  (let* ((title-text (thing-at-point 'line))
-         (safe-title-text (replace-regexp-in-string "^[ \*]" "" title-text))
-         (current-heading (org-present-trim-string safe-title-text)))
-    (run-hook-with-args 'org-present-after-navigate-functions (buffer-name) current-heading)))
+  "Fold slide if `org-present-startup-folded' is non-nil.
+Run org-present-after-navigate hook, passing the name of the presentation buffer and the current heading."
+  (progn
+    (if org-present-startup-folded (org-cycle))
+    (let* ((title-text (thing-at-point 'line))
+           (safe-title-text (replace-regexp-in-string "^[ \*]" "" title-text))
+           (current-heading (org-present-trim-string safe-title-text)))
+      (run-hook-with-args 'org-present-after-navigate-functions (buffer-name) current-heading))))
 
 (provide 'org-present)
 ;;; org-present.el ends here


### PR DESCRIPTION
This change seems appropriate to have in base `org-present` rather than as a
hook, because it accords with both parts of `org-present`.

 1. It fits with the `org` part because it is equivalent to
 `org-startup-folded`, but for presentation mode.
 2. It fits with the `present` part because it is analogous to the introduction
 of slide items by effects in other presentation programs: i.e., if you do not
 want to show the whole slide at first, but to unfurl it slowly.

We could have driven this feature of the `org-startup-folded` variable itself,
but it's probably making too much of a assumption about users' preferences to do
that. I want to make sure that this kind of change is opt-in for those who want
it and doesn't disturb existing users by suddenly changing behavior on an update.