### PR TITLE
Move org-present-narrow to be called after org-present-mode-hooks to …

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -233,8 +233,8 @@
   (interactive)
   (setq org-present-mode t)
   (org-present-add-overlays)
-  (org-present-narrow)
   (run-hooks 'org-present-mode-hook)
+  (org-present-narrow)
   (org-present-run-after-navigate-functions))
 
 (defun org-present-quit ()


### PR DESCRIPTION
…make sure images are shown inline in all slides.

Without this change I had an issue that inline-images will only display on the slide from which I launch org-present mode.

My theory is that it is because `org-present-narrow` is called before the `org-present-mode-hooks` which is where the command to display inline images is called.

So this change moves `org-present-narrow` invocation to happen after that of `org-present-mode-hooks` and it seems to work for me and others.

fixes #29 