### PR TITLE
Fixed that read-only function erase cursor

### DIFF
--- a/org-present.el
+++ b/org-present.el
@@ -206,25 +206,27 @@
   "Make buffer read-only."
   (interactive)
   (setq buffer-read-only t)
-  (setq org-present-cursor-cache cursor-type
-        cursor-type nil)
   (define-key org-present-mode-keymap (kbd "SPC") 'org-present-next))
 
 (defun org-present-read-write ()
   "Make buffer read-only."
   (interactive)
   (setq buffer-read-only nil)
-  (setq cursor-type org-present-cursor-cache)
   (define-key org-present-mode-keymap (kbd "SPC") 'self-insert-command))
 
 (defun org-present-hide-cursor ()
   "Hide the cursor for current window."
   (interactive)
+  (if cursor-type
+      (setq-local org-present-cursor-cache cursor-type
+            cursor-type nil))
   (internal-show-cursor (selected-window) nil))
 
 (defun org-present-show-cursor ()
   "Show the cursor for current window."
   (interactive)
+  (if org-present-cursor-cache
+      (setq-local cursor-type org-present-cursor-cache))
   (internal-show-cursor (selected-window) t))
 
 ;;;###autoload


### PR DESCRIPTION
Read-only function erase cursor, but there is a function to hide cursor. That's why I moved removing cursor process to the function to hide cursor.
Also, added a conditional expression because if the org-present-hide-cursor runs in duplicate, the cursor remains gone when leave the org-present-mode.(https://github.com/rlister/org-present/issues/14)